### PR TITLE
Add black-themed portfolio homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,27 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Hello World</title>
+  <title>Juergen Mathes - Projects</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Hi, I’m Jürgen 👋</h1>
-  <p>Welcome to my GitHub Pages site! !!!!!!!!!!!</p>
+  <main>
+    <h1>Hi, I’m Jürgen 👋</h1>
+    <p>Welcome to my corner of the internet. Here are some of my projects:</p>
+    <div class="table-container">
+      <table>
+        <thead>
+          <tr><th>Project</th><th>Description</th></tr>
+        </thead>
+        <tbody id="projects-body">
+        </tbody>
+      </table>
+    </div>
+    <footer>
+      <p id="footer-text"></p>
+    </footer>
+  </main>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,15 @@
+const projects = [
+  { name: 'Project Alpha', description: 'First project placeholder', link: '#' },
+  { name: 'Project Beta', description: 'Another project placeholder', link: '#' },
+  { name: 'Project Gamma', description: 'Yet another project placeholder', link: '#' }
+];
+
+const tbody = document.getElementById('projects-body');
+
+projects.forEach(p => {
+  const tr = document.createElement('tr');
+  tr.innerHTML = `<td><a href="${p.link}" target="_blank" rel="noopener noreferrer">${p.name}</a></td><td>${p.description}</td>`;
+  tbody.appendChild(tr);
+});
+
+document.getElementById('footer-text').textContent = `© ${new Date().getFullYear()} Jürgen Mathes`;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,68 @@
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #000;
+  color: #fff;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.table-container {
+  margin-top: 2rem;
+  border: 1px solid #444;
+  border-radius: 4px;
+  overflow: hidden;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background-color: #222;
+}
+
+th, td {
+  padding: 1rem;
+  text-align: left;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #111;
+}
+
+tbody tr:nth-child(even) {
+  background-color: #1a1a1a;
+}
+
+tbody tr:hover {
+  background-color: #333;
+}
+
+a {
+  color: #61dafb;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+footer {
+  margin-top: 3rem;
+  text-align: center;
+  color: #aaa;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- Replace placeholder page with black-themed portfolio
- Style page with responsive table for projects
- Populate sample projects via JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe3655740832c868066803d7b9508